### PR TITLE
Implement polling of POTA spots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=prerelease /usr/src/app/dxcluster/ ./dxcluster
 COPY --from=prerelease /usr/src/app/index.js .
 COPY --from=prerelease /usr/src/app/package.json .
+COPY --from=prerelease /usr/src/app/pota/ ./pota
 
 # run the app
 USER bun

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,8 @@ services:
       DXPORT: 8000	# Port of DXCluster upstream
       DXCALL: [my_call]	# Login-Call for Cluster
       DXPASSWORD: [my_password]	# Login-Passwort for Cluster (in most of all cases leave this blank!!
+      POTA_INTEGRATION: false	# wether to poll POTA for spots
+      POTA_POLLING_INTERVAL: 120	# polling interval for POTA in seconds
     ports:
       - 8192:8192	# Exposed port - see WEBPORT above
     restart: unless-stopped

--- a/hub/docker-compose.yaml
+++ b/hub/docker-compose.yaml
@@ -12,6 +12,8 @@ services:
       DXHOST: dxfun.com	# DNS of DXCluster upstream
       DXPORT: 8000	# Port of DXCluster upstream
       DXCALL: [my_call]	# Login-Call for Cluster
+      POTA_INTEGRATION: false	# wether to poll POTA for spots
+      POTA_POLLING_INTERVAL: 120	# polling interval for POTA in seconds
     ports:
       - 8192:8192	# Exposed port - see WEBPORT above
     restart: unless-stopped

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ conn.on('error', function(ex) {
 });
 
 conn.on('spot', async function x(spot) {
-	await handlespot(spot, false);
+	await handlespot(spot, "cluster");
 })
 
 //only initialize pota component if configured
@@ -93,7 +93,7 @@ if(config.includepotaspots || false){
 	pota.run();
 
 	pota.on('spot', async function x(spot) {
-		await handlespot(spot, true);
+		await handlespot(spot, "pota");
 	})
 }
 
@@ -110,7 +110,7 @@ async function main() {
 
 main();
 
-async function handlespot(spot, addpota = false){
+async function handlespot(spot, spot_source = "cluster"){
 
 	try {
 
@@ -120,7 +120,8 @@ async function handlespot(spot, addpota = false){
 			spotted: spot.spotted,
 			frequency: spot.frequency,
 			message: spot.message,
-			when: spot.when,		
+			when: spot.when,	
+			source: spot_source,	
 		}
 
 		//do DXCC lookup
@@ -128,7 +129,7 @@ async function handlespot(spot, addpota = false){
 		dxSpot.dxcc_spotted=await dxcc_lookup(spot.spotted);
 		
 		//add pota specific data
-		if(addpota){
+		if(spot_source == "pota"){
 			dxSpot.dxcc_spotted["pota_ref"] = spot.additional_data.pota_ref
 			dxSpot.dxcc_spotted["pota_mode"] = spot.additional_data.pota_mode
 		}

--- a/index.js
+++ b/index.js
@@ -258,8 +258,6 @@ async function handlespot(spot, spot_source = "cluster"){
 		//reduce spots
 		spots=reduce_spots(spots);
 		
-		//Log spot
-		console.log(dxSpot);
 	} catch(e) { 
 		console.error("Error processing spot:", e);
 	} 

--- a/index.js
+++ b/index.js
@@ -155,8 +155,8 @@ app.get(config.baseUrl + '/spots/:band', (req, res) => {
 app.get(config.baseUrl + '/stats', (req, res) => {
     const stats = {
         entries: spots.length,
-		cluster: spots.filter(item => item.source === 'cluster').length,
-		pota: spots.filter(item => item.source === 'pota').length,
+        cluster: spots.filter(item => item.source === 'cluster').length,
+        pota: spots.filter(item => item.source === 'pota').length,
         freshest: get_freshest(spots),
         oldest: get_oldest(spots)
     };

--- a/index.js
+++ b/index.js
@@ -155,6 +155,8 @@ app.get(config.baseUrl + '/spots/:band', (req, res) => {
 app.get(config.baseUrl + '/stats', (req, res) => {
     const stats = {
         entries: spots.length,
+		cluster: spots.filter(item => item.source === 'cluster').length,
+		pota: spots.filter(item => item.source === 'pota').length,
         freshest: get_freshest(spots),
         oldest: get_oldest(spots)
     };

--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ app.get(config.baseUrl + '/spots/:band', (req, res) => {
 });
 
 /**
- * GET /spots/:source - Retrieve all cached spots from a given source.
+ * GET /spots/source/:source - Retrieve all cached spots from a given source.
  */
 app.get(config.baseUrl + '/spots/source/:source', (req, res) => {
     const sourcespots = get_sourcespots(req.params.source);

--- a/index.js
+++ b/index.js
@@ -150,6 +150,14 @@ app.get(config.baseUrl + '/spots/:band', (req, res) => {
 });
 
 /**
+ * GET /spots/:source - Retrieve all cached spots from a given source.
+ */
+app.get(config.baseUrl + '/spots/source/:source', (req, res) => {
+    const sourcespots = get_sourcespots(req.params.source);
+    res.json(sourcespots);
+});
+
+/**
  * GET /stats - Retrieve statistics about the cached spots.
  */
 app.get(config.baseUrl + '/stats', (req, res) => {
@@ -363,6 +371,15 @@ function get_singlespot(qrg) {
  */
 function get_bandspots(band) {
     return spots.filter((single) => single.band === band);
+}
+
+/**
+ * Retrieves all spots for a given source.
+ * @param {string} source - The source to search for.
+ * @returns {array} - An array of spots for the given source.
+ */
+function get_sourcespots(source) {
+    return spots.filter((single) => single.source === source);
 }
 
 /**

--- a/pota/index.js
+++ b/pota/index.js
@@ -1,0 +1,96 @@
+const net = require('net');
+const events = require('events');
+
+const sleepNow = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
+
+module.exports = class POTASpots extends events.EventEmitter {
+  
+  //constructor
+  constructor(opts = {}) {
+    super();
+    this.potapollinterval = opts.potapollinterval || 120; // Default to 120 seconds
+    this.potaspotcache = [];
+  }
+
+  getalloweddeviation(mode)
+  {
+    //allow FT8 and FT4 to be up to 3khz off to be sure to catch all in-band-frequency changes and wobbly receivers
+    switch (mode) {
+      case "FT8":
+        return 3;
+      case "FT4":
+        return 3;
+      default:
+        return 1;
+    }
+  }
+
+  //continuously poll POTA API, determine new spots and emit those to event listeners
+  async run(opts = {}) {
+    while (true) {
+      
+      //Wait for the polling interval
+      await sleepNow(this.potapollinterval * 1000);
+
+      //cache variable
+      let spots = [];
+
+      //Try to get data from POTA API
+      try {
+        
+        //fetch api response, 10s timeout
+        const response = await fetch('https://api.pota.app/spot/activator', { signal: AbortSignal.timeout(10000) });
+        if (!response.ok) throw new Error('HTTP error');
+
+        //get json from response
+        let rawspots = await response.json();
+
+        //iterate through each spot
+        rawspots.forEach((item, index) => {
+        
+          // build POTA spot
+          let dxSpot = {
+              spotter: item.spotter,
+              spotted: item.activator,
+              frequency: item.frequency,
+              message: item.mode + (item.mode != '' ? " " : "") + "POTA @ " + item.reference + " " + item.name + " (" + item.locationDesc + ")",
+              when: new Date(),
+              additional_data: {
+                pota_ref: item.reference,
+                pota_mode: item.mode
+              }
+              
+          }
+
+          //put spots inside of array to build new
+          spots.push(dxSpot);
+
+          //check if the same spot (excluding "when") exists in cache
+          //use an allowed deviation on frequency to catch multiple spots by RBN or PSK-Reporter for FT8, FT4 and CW modes
+          let isNewSpot = !this.potaspotcache.some(existingSpot => 
+            existingSpot.spotted === dxSpot.spotted &&
+            Math.abs(existingSpot.frequency - dxSpot.frequency) <= this.getalloweddeviation(item.mode) &&
+            existingSpot.message === dxSpot.message
+          );
+
+          //emit spot to event listeners
+          if(isNewSpot)
+          {
+            this.emit('spot', dxSpot)
+          }
+          
+          
+        });
+
+        //set the potacache to the current state, effectively deleting all old spots
+        this.potaspotcache = spots;
+        
+      } catch (error) {
+        //log error to console
+        console.error('Fetch failed:', error);
+      }
+
+    }
+
+  }
+};

--- a/pota/index.js
+++ b/pota/index.js
@@ -50,15 +50,15 @@ module.exports = class POTASpots extends events.EventEmitter {
         
           // build POTA spot
           let dxSpot = {
-              spotter: item.spotter,
-              spotted: item.activator,
-              frequency: item.frequency,
-              message: item.mode + (item.mode != '' ? " " : "") + "POTA @ " + item.reference + " " + item.name + " (" + item.locationDesc + ")",
-              when: new Date(),
-              additional_data: {
-                pota_ref: item.reference,
-                pota_mode: item.mode
-              }
+            spotter: item.spotter,
+            spotted: item.activator,
+            frequency: item.frequency,
+            message: item.mode + (item.mode != '' ? " " : "") + "POTA @ " + item.reference + " " + item.name + " (" + item.locationDesc + ")",
+            when: new Date(),
+            additional_data: {
+              pota_ref: item.reference,
+              pota_mode: item.mode
+            }
               
           }
 
@@ -77,9 +77,7 @@ module.exports = class POTASpots extends events.EventEmitter {
           if(isNewSpot)
           {
             this.emit('spot', dxSpot)
-          }
-          
-          
+          }          
         });
 
         //set the potacache to the current state, effectively deleting all old spots
@@ -89,8 +87,6 @@ module.exports = class POTASpots extends events.EventEmitter {
         //log error to console
         console.error('Fetch failed:', error);
       }
-
     }
-
   }
 };


### PR DESCRIPTION
This implements the polling of the POTA API to get current POTA spots.

Default polling rate is each 120 seconds, but is configurable for every user.

Only new spots (after sensible deduplication) get added to the cache for display in wavelog or other software.

