### PR TITLE
Skip POTA Spots without a valid frequency

### DIFF
--- a/pota/index.js
+++ b/pota/index.js
@@ -27,66 +27,67 @@ module.exports = class POTASpots extends events.EventEmitter {
 
   //continuously poll POTA API, determine new spots and emit those to event listeners
   async run(opts = {}) {
-    while (true) {
-      
-      //Wait for the polling interval
-      await sleepNow(this.potapollinterval * 1000);
+	  while (true) {
 
-      //cache variable
-      let spots = [];
+		  //Wait for the polling interval
+		  await sleepNow(this.potapollinterval * 1000);
 
-      //Try to get data from POTA API
-      try {
-        
-        //fetch api response, 10s timeout
-        const response = await fetch('https://api.pota.app/spot/activator', { signal: AbortSignal.timeout(10000) });
-        if (!response.ok) throw new Error('HTTP error');
+		  //cache variable
+		  let spots = [];
 
-        //get json from response
-        let rawspots = await response.json();
+		  //Try to get data from POTA API
+		  try {
 
-        //iterate through each spot
-        rawspots.forEach((item, index) => {
-        
-          // build POTA spot
-          let dxSpot = {
-            spotter: item.spotter,
-            spotted: item.activator,
-            frequency: item.frequency,
-            message: item.mode + (item.mode != '' ? " " : "") + "POTA @ " + item.reference + " " + item.name + " (" + item.locationDesc + ")",
-            when: new Date(),
-            additional_data: {
-              pota_ref: item.reference,
-              pota_mode: item.mode
-            }
-              
-          }
+			  //fetch api response, 10s timeout
+			  const response = await fetch('https://api.pota.app/spot/activator', { signal: AbortSignal.timeout(10000) });
+			  if (!response.ok) throw new Error('HTTP error');
 
-          //put spots inside of array to build new
-          spots.push(dxSpot);
+			  //get json from response
+			  let rawspots = await response.json();
 
-          //check if the same spot (excluding "when") exists in cache
-          //use an allowed deviation on frequency to catch multiple spots by RBN or PSK-Reporter for FT8, FT4 and CW modes
-          let isNewSpot = !this.potaspotcache.some(existingSpot => 
-            existingSpot.spotted === dxSpot.spotted &&
-            Math.abs(existingSpot.frequency - dxSpot.frequency) <= this.getalloweddeviation(item.mode) &&
-            existingSpot.message === dxSpot.message
-          );
+			  //iterate through each spot
+			  rawspots.forEach((item, index) => {
+				  // build POTA spot
+				  let dxSpot = {
+					  spotter: item.spotter,
+					  spotted: item.activator,
+					  frequency: item.frequency,
+					  message: item.mode + (item.mode != '' ? " " : "") + "POTA @ " + item.reference + " " + item.name + " (" + item.locationDesc + ")",
+						  when: new Date(),
+					  additional_data: {
+						  pota_ref: item.reference,
+						  pota_mode: item.mode
+					  }
 
-          //emit spot to event listeners
-          if(isNewSpot)
-          {
-            this.emit('spot', dxSpot)
-          }          
-        });
+				  }
 
-        //set the potacache to the current state, effectively deleting all old spots
-        this.potaspotcache = spots;
-        
-      } catch (error) {
-        //log error to console
-        console.error('Fetch failed:', error);
-      }
-    }
+				  if (!isNaN(item.frequency)) { 	// ignore POTA-Spots without (valid) frequency
+					  //put spots inside of array to build new
+					  spots.push(dxSpot);
+
+					  //check if the same spot (excluding "when") exists in cache
+					  //use an allowed deviation on frequency to catch multiple spots by RBN or PSK-Reporter for FT8, FT4 and CW modes
+					  let isNewSpot = !this.potaspotcache.some(existingSpot => 
+										   existingSpot.spotted === dxSpot.spotted &&
+											   Math.abs(existingSpot.frequency - dxSpot.frequency) <= this.getalloweddeviation(item.mode) &&
+											   existingSpot.message === dxSpot.message
+										  );
+
+										  //emit spot to event listeners
+										  if(isNewSpot)
+											  {
+												  this.emit('spot', dxSpot)
+											  }          
+				  }
+			  });
+
+			  //set the potacache to the current state, effectively deleting all old spots
+			  this.potaspotcache = spots;
+
+		  } catch (error) {
+			  //log error to console
+			  console.error('Fetch failed:', error);
+		  }
+	  }
   }
 };


### PR DESCRIPTION
Sometimes (for whatever reason) POTA emits a spot without a numeric frequency.
This causes a lot of problems (besides the fact, that a spot without frequency is senseless).

Mitigated at two places:
1.) With this patch
2.) at Wavelog itself - see https://github.com/wavelog/wavelog/commit/3fe67320e060d460852326806e0a5065fead83bd

@DB4SCW FYI !